### PR TITLE
Support for forcing dark mode on older Electron

### DIFF
--- a/src/dwm.rs
+++ b/src/dwm.rs
@@ -30,6 +30,7 @@ use super::VibeError;
 
 type WINDOWCOMPOSITIONATTRIB = u32;
 
+const DWMWA_USE_IMMERSIVE_DARK_MODE: DWMWINDOWATTRIBUTE = 20i32;
 const DWMWA_MICA_EFFECT: DWMWINDOWATTRIBUTE = 1029i32;
 const DWMWA_SYSTEMBACKDROP_TYPE: DWMWINDOWATTRIBUTE = 38i32;
 
@@ -152,6 +153,36 @@ unsafe fn fix_client_area(hwnd: HWND) {
 		cyTopHeight: -1
 	};
 	DwmExtendFrameIntoClientArea(hwnd, &margins);
+}
+
+pub fn force_dark_theme(hwnd: HWND) -> Result<(), VibeError> {
+	if is_win11() {
+		unsafe {
+			DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &1 as *const _ as _, 4);
+		}
+	} else if is_win10_swca() {
+		unsafe {
+			DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE - 1, &1 as *const _ as _, 4);
+		}
+	} else {
+		return Err(VibeError::UnsupportedPlatformVersion("\"force_dark_theme()\" is only available on Windows 10 v1809+ or Windows 11"));
+	}
+	Ok(())
+}
+
+pub fn force_light_theme(hwnd: HWND) -> Result<(), VibeError> {
+	if is_win11() {
+		unsafe {
+			DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &0 as *const _ as _, 4);
+		}
+	} else if is_win10_swca() {
+		unsafe {
+			DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE - 1, &0 as *const _ as _, 4);
+		}
+	} else {
+		return Err(VibeError::UnsupportedPlatformVersion("\"force_light_theme()\" is only available on Windows 10 v1809+ or Windows 11"));
+	}
+	Ok(())
 }
 
 pub fn apply_acrylic(hwnd: HWND) -> Result<(), VibeError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,10 +127,40 @@ pub fn clear_effects(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 	Ok(cx.undefined())
 }
 
+pub fn set_dark_mode(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+	let browser_window = cx.argument::<JsObject>(0)?;
+	let get_native_window_handle: Handle<JsFunction> = browser_window.get(&mut cx, "getNativeWindowHandle")?;
+	let native_window_handle: Handle<JsObject> = get_native_window_handle.call(&mut cx, browser_window, [])?.downcast_or_throw(&mut cx)?;
+	let read_int32_le: Handle<JsFunction> = native_window_handle.get(&mut cx, "readInt32LE")?;
+	let hwnd = read_int32_le
+		.call(&mut cx, native_window_handle, [])?
+		.downcast_or_throw::<JsNumber, FunctionContext>(&mut cx)?
+		.value(&mut cx) as windows_sys::Win32::Foundation::HWND;
+
+	let _ = dwm::force_dark_theme(hwnd);
+	Ok(cx.undefined())
+}
+
+pub fn set_light_mode(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+	let browser_window = cx.argument::<JsObject>(0)?;
+	let get_native_window_handle: Handle<JsFunction> = browser_window.get(&mut cx, "getNativeWindowHandle")?;
+	let native_window_handle: Handle<JsObject> = get_native_window_handle.call(&mut cx, browser_window, [])?.downcast_or_throw(&mut cx)?;
+	let read_int32_le: Handle<JsFunction> = native_window_handle.get(&mut cx, "readInt32LE")?;
+	let hwnd = read_int32_le
+		.call(&mut cx, native_window_handle, [])?
+		.downcast_or_throw::<JsNumber, FunctionContext>(&mut cx)?
+		.value(&mut cx) as windows_sys::Win32::Foundation::HWND;
+
+	let _ = dwm::force_light_theme(hwnd);
+	Ok(cx.undefined())
+}
+
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
 	cx.export_function("applyEffect", apply_effect)?;
 	cx.export_function("clearEffects", clear_effects)?;
+	cx.export_function("setDarkMode", set_dark_mode)?;
+	cx.export_function("setLightMode", set_light_mode)?;
 	cx.export_function("setup", setup)?;
 	Ok(())
 }


### PR DESCRIPTION
Older Electron versions do not support changing the theme using `nativeTheme`, but it's easily doable native side using DwmSWA and the [USE_IMMERSIVE_DARK_MODE](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute) flag.
This does not have a Mutex for the "dark mode" state, as it could be changed by Electron if used on a newer version.